### PR TITLE
Add space-evenly value to relevant flexbox properties

### DIFF
--- a/pages/rcss/flexboxes.md
+++ b/pages/rcss/flexboxes.md
@@ -207,7 +207,7 @@ Note that any free space filled by auto-margins will thereby leave no more space
 `justify-content`{:.prop}
 {:#justify-content}
 
-Value: | flex-start \| flex-end \| center \| space-between \| space-around
+Value: | flex-start \| flex-end \| center \| space-between \| space-around \| space-evenly
 Initial: | flex-start
 Applies to: | flex containers
 Inherited: | no
@@ -244,7 +244,7 @@ Override the cross-axis alignment specified on the parent container for this ite
 `align-content`{:.prop}
 {:#align-content}
 
-Value: | flex-start \| flex-end \| center \| space-between \| space-around \| stretch
+Value: | flex-start \| flex-end \| center \| space-between \| space-around \| space-evenly \| stretch
 Initial: | stretch
 Applies to: | multi-line flex containers
 Inherited: | no

--- a/pages/rcss/property_index.md
+++ b/pages/rcss/property_index.md
@@ -9,7 +9,7 @@ The following table lists all properties recognised by RCSS. The **Notes** colum
 
 Name | Values | Initial value | Applies to | Inherited | Percentages | Notes
 ---- | ------ | ------------- | ---------- | ---------- | ----------- | -----
-[`align-content`{:.prop}][align-content] |flex-start \| flex-end \| center \| space-between \| space-around \| stretch | stretch | multi-line flex containers | no | | 
+[`align-content`{:.prop}][align-content] |flex-start \| flex-end \| center \| space-between \| space-around \| space-evenly \| stretch | stretch | multi-line flex containers | no | | 
 [`align-items`{:.prop}][align-items] | flex-start \| flex-end \| center \| baseline \| space-around \| stretch | stretch | flex containers | no | | 
 [`align-self`{:.prop}][align-self] | auto \| flex-start \| flex-end \| center \| baseline \| space-around \| stretch | auto | flex containers | no | | 
 [`animation`{:.prop}][animation] | See [animations](animations_transitions_transforms.html#animation) | none | all | no | | 
@@ -53,7 +53,7 @@ Name | Values | Initial value | Applies to | Inherited | Percentages | Notes
 [`gap`{:.prop}][gap] | `row-gap`{:.prop} `column-gap`{:.prop} | | table elements | | | Replaces the CSS `border-spacing`{:.prop} property.
 [`height`{:.prop}][height] | \<length\> \| \<percentage\> \| auto | auto | block and replaced inline elements | no | height of containing block | 
 [`image-color`{:.prop}][image-color] | \<color\> | white | \<img\> elements and decorators | no | | Introduced for RCSS.
-[`justify-content`{:.prop}][justify-content] | flex-start \| flex-end \| center \| space-between \| space-around | flex-start | flex containers | no | | 
+[`justify-content`{:.prop}][justify-content] | flex-start \| flex-end \| center \| space-between \| space-around \| space-evenly | flex-start | flex containers | no | | 
 [`left`{:.prop}][top_right_bottom_left] | auto \| \<length\> \| \<percentage\> | auto | positioned elements | no | width of containing block | 
 [`letter-spacing`{:.prop}][letter-spacing] | normal \| \<length\> | normal | all elements | yes | | 
 [`line-height`{:.prop}][line-height] | \<number\> \| \<length\> \| \<percentage\> | 1.2 | all | yes | font size | 'normal' not supported.


### PR DESCRIPTION
A small change that adds `space-evenly` to the value lists of the `justify-content` and `align-content` properties.