### PR TITLE
Add documentation for localisation attributes

### DIFF
--- a/pages/rcss/property_index.md
+++ b/pages/rcss/property_index.md
@@ -94,6 +94,15 @@ Name | Values | Initial value | Applies to | Inherited | Percentages | Notes
 [`width`{:.prop}][width] | \<length\> \| \<percentage\> \| auto | auto | block and replaced inline elements | no | width of containing block | 
 [`z-index`{:.prop}][z-index] | \<number\> \| auto | auto | all | no | | Applies to all elements. For documents, 'auto' allows pulling to front, otherwise remains at top or bottom. 
 
+### Internal Properties
+
+The following properties are internal to RmlUi. Ideally, they are set automatically by their respective global attribute, but can be set manually by the user if desired.
+
+Name | Values | Initial value | Applies to | Inherited | Global attribute | Notes
+---- | ------ | ------------- | ---------- | --------- | ---------------- | -----
+[`--rmlui-direction`{:.prop}][--rmlui-direction] | ltr \| rtl \| auto | auto | all | yes | `dir`{:.attr} | Unlike `direction`{:.prop} from CSS, this property does not affect document layout. 
+[`--rmlui-language`{:.prop}][--rmlui-language] | \<string\> | | all | yes | `lang`{:.attr} | 
+
 
 [align-content]: flexboxes.html#align-content
 [align-items]: flexboxes.html#align-items
@@ -166,3 +175,6 @@ Name | Values | Initial value | Applies to | Inherited | Percentages | Notes
 [width]: visual_formatting_model_details.html#width
 [word-break]: text.html#word-break
 [z-index]: visual_formatting_model.html#z-index
+
+[--rmlui-direction]: {{"pages/rml/elements.html#global-attributes"|relative_url}}
+[--rmlui-language]: {{"pages/rml/elements.html#global-attributes"|relative_url}}

--- a/pages/rcss/property_index.md
+++ b/pages/rcss/property_index.md
@@ -94,15 +94,6 @@ Name | Values | Initial value | Applies to | Inherited | Percentages | Notes
 [`width`{:.prop}][width] | \<length\> \| \<percentage\> \| auto | auto | block and replaced inline elements | no | width of containing block | 
 [`z-index`{:.prop}][z-index] | \<number\> \| auto | auto | all | no | | Applies to all elements. For documents, 'auto' allows pulling to front, otherwise remains at top or bottom. 
 
-### Internal Properties
-
-The following properties are internal to RmlUi. Ideally, they are set automatically by their respective global attribute, but can be set manually by the user if desired.
-
-Name | Values | Initial value | Applies to | Inherited | Global attribute | Notes
----- | ------ | ------------- | ---------- | --------- | ---------------- | -----
-[`--rmlui-direction`{:.prop}][--rmlui-direction] | ltr \| rtl \| auto | auto | all | yes | `dir`{:.attr} | Unlike `direction`{:.prop} from CSS, this property does not affect document layout. 
-[`--rmlui-language`{:.prop}][--rmlui-language] | \<string\> | | all | yes | `lang`{:.attr} | 
-
 
 [align-content]: flexboxes.html#align-content
 [align-items]: flexboxes.html#align-items
@@ -175,6 +166,3 @@ Name | Values | Initial value | Applies to | Inherited | Global attribute | Note
 [width]: visual_formatting_model_details.html#width
 [word-break]: text.html#word-break
 [z-index]: visual_formatting_model.html#z-index
-
-[--rmlui-direction]: {{"pages/rml/elements.html#global-attributes"|relative_url}}
-[--rmlui-language]: {{"pages/rml/elements.html#global-attributes"|relative_url}}

--- a/pages/rml/elements.md
+++ b/pages/rml/elements.md
@@ -25,10 +25,10 @@ Elements have a base set of attributes that are common to all types, which are:
 : Specifies inline style information for the element. See [RCSS](../rcss.html).
 
 `lang`{:.attr} = language-code (CI)
-: Specifies the language of the element. Value is passed to the font engine to assist with text shaping.
+: Specifies the language of the element's text. Value is passed to the font engine to assist with text shaping. Inherited by child elements.
 
 `dir`{:.attr} = ltr | rtl | auto (CS)
-: Specifies the text-flow direction of the element. Value is passed to the font engine to assist with text shaping. Unlike HTML, this attribute is case-sensitive and does not affect document layout.
+: Specifies the flow direction of the element's text. Value is passed to the font engine to assist with text shaping. Inherited by child elements. Unlike HTML, this attribute is case-sensitive and does not affect document layout.
 
 `on*`{:.attr} events = cdata (CS)
 : Event bindings. See [Events](events.html).

--- a/pages/rml/elements.md
+++ b/pages/rml/elements.md
@@ -24,6 +24,12 @@ Elements have a base set of attributes that are common to all types, which are:
 `style`{:.attr} = cdata (CS)
 : Specifies inline style information for the element. See [RCSS](../rcss.html).
 
+`lang`{:.attr} = language-code (CI)
+: Specifies the language of the element. Value is passed to the font engine to assist with text shaping.
+
+`dir`{:.attr} = ltr | rtl | auto (CS)
+: Specifies the text-flow direction of the element. Value is passed to the font engine to assist with text shaping. Unlike HTML, this attribute is case-sensitive and does not affect document layout.
+
 `on*`{:.attr} events = cdata (CS)
 : Event bindings. See [Events](events.html).
 


### PR DESCRIPTION
This PR adds documentation for the internal localisation properties and attributes added a few weeks ago.

I added a section at the bottom of the property index for internal properties. I also added the `dir` and `lang` global attributes to the global attribute list.