### PR TITLE
Update and streamline the copyright

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2008-2014 CodePoint Ltd, Shift Technology Ltd, and contributors  
-Copyright (c) 2019-2021 The RmlUi Team, and contributors
+Copyright (c) 2019-2023 The RmlUi Team, and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/_includes/themes/librocket/default.html
+++ b/_includes/themes/librocket/default.html
@@ -129,7 +129,7 @@
           {{ page.lib_name }} is licensed under the terms and conditions of the 
           <a href="{{ "pages/license.html" | relative_url }}">MIT license</a>.<br />
           Copyright (c) 2008-2014 CodePoint Ltd, Shift Technology Ltd, and contributors<br />
-          Copyright (c) 2019-2021 The RmlUi Team, and contributors<br />
+          Copyright (c) 2019-2023 The RmlUi Team, and contributors<br />
           <a href="{{ page.lib_site }}">{{ page.lib_name }} source code and release packages</a>
         </small></p>
       </footer>

--- a/pages/license.md
+++ b/pages/license.md
@@ -6,7 +6,7 @@ include_in_search_results: false
 ---
 
 Copyright (c) 2008-2014 CodePoint Ltd, Shift Technology Ltd, and contributors  
-Copyright (c) 2019 The {{ page.lib_name }} Team, and contributors
+Copyright (c) 2019-2023 The RmlUi Team, and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
I was tempted to use 2024, but that would not match [the original license](https://github.com/mikke89/RmlUi/blob/master/LICENSE.txt).

Furthermore, I streamlined the copyrights as they were slightly different for all three places.