### PR TITLE
Remove a mention of the flexbox's gap property not being supported

### DIFF
--- a/pages/rcss/flexboxes.md
+++ b/pages/rcss/flexboxes.md
@@ -73,7 +73,6 @@ The rendered output is shown below. Notice that all columns are the same height.
 ##### Properties and values
 
 - Property `order`{:.prop} is not supported.
-- Property `gap`{:.prop} is not currently supported for flexbox.
 - Property value `flex-basis: content`{:.value} is not supported.
 - Property value `visibility: collapse`{:.value} is not supported.
 


### PR DESCRIPTION
I believe this is an oversight, and it should have been a part of https://github.com/mikke89/RmlUiDoc/commit/d7af397dd94e92ac720d5ccc468557ed5a6e858a, as the `gap` property was added in https://github.com/mikke89/RmlUi/pull/621.