### PR TITLE
Explain the consequence of fixed intrinsic width and mention that shrink-to-fit width is not implemented for tables

### DIFF
--- a/pages/rcss/flexboxes.md
+++ b/pages/rcss/flexboxes.md
@@ -185,7 +185,7 @@ Applies to: | flex items
 Inherited: | no
 Percentages: | relative to the flex container’s inner main size
 
-Sets the flex item's basis size. That is, this gives the initial size before the item is grown or shrinked using the above factors. When specified as `auto`{:.value}, the item's shrink-to-fit width will be used – or automatic block height in column layout. Otherwise, units are resolved the same way as for the [`width`{:.prop} property](visual_formatting_model_details.html#width). Note that shrink-to-fit width is not implemented for tables.
+Sets the flex item's basis size. That is, this gives the initial size before the item is grown or shrinked using the above factors. When specified as `auto`{:.value}, the item's shrink-to-fit width will be used – or automatic block height in column layout. Otherwise, units are resolved the same way as for the [`width`{:.prop} property](visual_formatting_model_details.html#width). Note that shrink-to-fit width is not implemented for tables, so they will be treated as a zero-width box when `flex-basis`{:.prop} is `auto`{:.value}, which usually leads to unsatisfactory layouting results.
 
 
 ### Alignment

--- a/pages/rcss/flexboxes.md
+++ b/pages/rcss/flexboxes.md
@@ -185,7 +185,7 @@ Applies to: | flex items
 Inherited: | no
 Percentages: | relative to the flex container’s inner main size
 
-Sets the flex item's basis size. That is, this gives the initial size before the item is grown or shrinked using the above factors. When specified as `auto`{:.value}, the item's shrink-to-fit width will be used – or automatic block height in column layout. Otherwise, units are resolved the same way as for the [`width`{:.prop} property](visual_formatting_model_details.html#width).
+Sets the flex item's basis size. That is, this gives the initial size before the item is grown or shrinked using the above factors. When specified as `auto`{:.value}, the item's shrink-to-fit width will be used – or automatic block height in column layout. Otherwise, units are resolved the same way as for the [`width`{:.prop} property](visual_formatting_model_details.html#width). Note that shrink-to-fit width is not implemented for tables.
 
 
 ### Alignment

--- a/pages/rcss/visual_formatting_model.md
+++ b/pages/rcss/visual_formatting_model.md
@@ -18,7 +18,7 @@ The differences between CSS and RCSS are:
 During document layout, each element generates zero or more boxes. How these boxes are sized and laid out within their document is governed by:
 
 * The box type (either block, for boxes generally laid out top-to-bottom, or inline, for boxes laid out along a line).
-* The box size; this could either be derived from intrinsic dimensions for elements such as images and form controls, or specified directly through RCSS properties, or determined by the contents of the box. Note that unlike in a full-fledged browser, elements like `select`{:.tag} have a fixed intrinsic size, which is not determined by their content, so their size have to be specified by other means, see [here](visual_formatting_model_details.html#calculating-widths-and-margins) and [here](visual_formatting_model_details.html#calculating-heights-and-margins) to know how is the width and height determined. A [flexbox](flexboxes.html) with stretched align properties can also be used to stretch the size of a box that's not a inline non-replaced box.
+* The box size; this could either be derived from intrinsic dimensions for elements such as images and form controls, or specified directly through RCSS properties, or determined by the contents of the box.
 * Relationships of the box to other boxes in the document tree, such as floating boxes.
 
 #### Containing blocks

--- a/pages/rcss/visual_formatting_model.md
+++ b/pages/rcss/visual_formatting_model.md
@@ -18,7 +18,7 @@ The differences between CSS and RCSS are:
 During document layout, each element generates zero or more boxes. How these boxes are sized and laid out within their document is governed by:
 
 * The box type (either block, for boxes generally laid out top-to-bottom, or inline, for boxes laid out along a line).
-* The box size; this could either be derived from intrinsic dimensions for elements such as images and form controls, or specified directly through RCSS properties, or determined by the contents of the box.
+* The box size; this could either be derived from intrinsic dimensions for elements such as images and form controls, or specified directly through RCSS properties, or determined by the contents of the box. Note that unlike in a full-fledged browser, elements like `select`{:.tag} have a fixed intrinsic size, which is not determined by their content, so their size have to be specified by other means, see [here](visual_formatting_model_details.html#calculating-widths-and-margins) and [here](visual_formatting_model_details.html#calculating-heights-and-margins) to know how is the width and height determined. A [flexbox](flexboxes.html) with stretched align properties can also be used to stretch the size of a box that's not a inline non-replaced box.
 * Relationships of the box to other boxes in the document tree, such as floating boxes.
 
 #### Containing blocks

--- a/pages/rcss/visual_formatting_model.md
+++ b/pages/rcss/visual_formatting_model.md
@@ -11,6 +11,7 @@ The differences between CSS and RCSS are:
 
 * The dimensions of the viewport are defined as the dimensions of the context the document is being rendered in.
 * The document element (the root) is always absolutely positioned, and can be positioned within its context using `top`{:.prop}, `right`{:.prop}, `bottom`{:.prop} and `left`{:.prop}.
+* There are no default styles in RCSS, including for built-in elements such as scrollbars and form controls. Please see the [style guide](../style_guide.html) for how to style and size these elements.
 * Generated content is not yet supported.
 
 ### Introduction to the visual formatting model

--- a/pages/style_guide.md
+++ b/pages/style_guide.md
@@ -190,6 +190,10 @@ input.range slidertrack
 
 Drop-down boxes can be instanced through the RML tag `<select>`{:.tag}, with individual options specified within the selection element with `<option>`{:.tag} tags.
 
+#### Intrinsic size
+
+Drop-down boxes in RmlUi have a fixed intrinsic size rather than adapting the size to their contents, as is common behavior in web browsers. Instead, the `width`{:.prop} and `height`{:.prop} properties should be specified explicitly to achieve the desired size.
+
 #### Generated elements
 
 The select element generates three hidden elements:


### PR DESCRIPTION
People who are more familiar with css behavior in the browsers (like me) should find this useful.