### PR TITLE
Document selecting fonts from collections.

### DIFF
--- a/pages/cpp_manual/fonts.md
+++ b/pages/cpp_manual/fonts.md
@@ -10,47 +10,51 @@ TrueType and OpenType fonts can be loaded into RmlUi by the application. RmlUi h
 To load a font, call one of the `Rml::LoadFontFace()` functions. The simplest of these takes a file name and optional fallback and weight parameters:
 
 ```cpp
-// Adds a new font face to the font engine. The face's family, style and weight will be determined from the face itself.
-// @param[in] file_name The file to load the face from.
+// Adds a new font face to the font engine. The face's family, style, and weight will be determined from the face itself.
+// @param[in] file_path The path to the file to load the face from. The path is passed directly to the file interface which is used to load the file. The default file interface accepts both absolute paths and paths relative to the working directory.
 // @param[in] fallback_face True to use this font face for unknown characters in other font faces.
-// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as. By
-// default it loads all found font weights.
+// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as. By default, it loads all found font weights.
+// @param[in] face_index The index of the font face within a font collection.
 // @return True if the face was loaded successfully, false otherwise.
-bool LoadFontFace(const String& file_name, bool fallback_face = false, Style::FontWeight weight = Style::FontWeight::Auto);
+bool LoadFontFace(const String& file_path,
+                  bool fallback_face = false,
+                  Style::FontWeight weight = Style::FontWeight::Auto,
+                  int face_index = 0);
 ```
 
 This function will load the font file specified (opening it through the file interface). The font's family (the string you specify the font with using the `font-family`{:.prop} RCSS property), the style (normal or italic) and by default the weight are all fetched from the font file itself. RmlUi will generate the font data for specific sizes of the font as required by the application. Note that if you are loading a .ttc, only the first font will be registered.
 
-If enabled, the `fallback_face` option will make the given font face be used for any unknown characters in other fonts. This is useful for example to provide a single font face for emojis, and another one providing characters for e.g. cyrillic or greek. Then these fonts will be used whenever characters encountered are not located in the fonts specified by the document. Multiple fallback faces can be used, and they will be prioritized in the order they were loaded.
+If enabled, the `fallback_face` option will make the given font face be used for any unknown characters in other fonts. This is useful for example to provide a single font face for emojis, and another one providing characters for Cyrillic, Greek, and similar. These fonts will then be used whenever characters encountered are not located in the fonts specified by the document. Multiple fallback faces can be used, and they will be prioritized in the order they were loaded.
 
 When the `weight` parameter is `Auto`{:.value} the weight is automatically retrieved from the font. Further, if the font contains multiple weight variations then all of them are loaded. Any other value of `weight` is either used to override the registered weight, or when there are multiple weights in the face, choose which weight variation to load.
 
 Overriding the default `weight` parameter can be done by one of `Rml::Style::FontWeight::Normal`{:.value}, `Bold`{:.value}, or any numeric value \[1,1000\] by casting, for example `(Rml::Style::FontWeight)850`{:.value}.
 
+The `face_index` parameter allows selection of font faces within font collections. This is useful for loading a single font file with multiple faces.
+
 If you need to load a font face from memory, and override the family name, style or weight of the font, use the more complex `LoadFontFace()`:
 
 ```cpp
-// Adds a new font face from memory to the font engine. The face's family, style and weight is given by the parameters.
-// @param[in] data A pointer to the data.
-// @param[in] data_size Size of the data in bytes.
+// Adds a new font face from memory to the font engine. The face's family, style, and weight are given by the parameters.
+// @param[in] data The font data.
 // @param[in] family The family to register the font as.
 // @param[in] style The style to register the font as.
-// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as. By
-// default it loads all found font weights.
+// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as. By default, it loads all found font weights.
 // @param[in] fallback_face True to use this font face for unknown characters in other font faces.
+// @param[in] face_index The index of the font face within a font collection.
 // @return True if the face was loaded successfully, false otherwise.
 // @lifetime The pointed to 'data' must remain available until after the call to Rml::Shutdown.
-static bool LoadFontFace(const byte* data,
-                         int data_size, 
-                         const String& family,
-                         Style::FontStyle style,
-                         Style::FontWeight weight = Style::FontWeight::Auto,
-                         bool fallback_face = false);
+bool LoadFontFace(Span<const byte> data,
+                  const String& family,
+                  Style::FontStyle style,
+                  Style::FontWeight weight = Style::FontWeight::Auto,
+                  bool fallback_face = false,
+                  int face_index = 0);
 ```
 
 - When the provided `family` is empty, the font family and style is automatically retrieved from the font.
 - `style` is one of `Rml::Style::FontStyle::Normal`{:.value} or `Italic`{:.value}.
-- The `weight` and `fallback_face` parameters work exactly like in the above function.
+- The `weight`, `fallback_face`, and `face_index` parameters work exactly like in the above function.
 
 The italic and bold versions of a font are selected with the `font-weight`{:.prop} and `font-style`{:.prop} RCSS properties.
 
@@ -64,10 +68,7 @@ In this example, the font file is loaded from memory with overrides for the name
 
 ```cpp
 std::vector<unsigned char> trilobyte_b = MyAssetLoader("data/trilobyte_b.ttf");
-Rml::LoadFontFace(trilobyte_b.data(), trilobyte_b.size(),
-                  "Trilobyte",
-                  Rml::Style::FontStyle::Normal,
-                  Rml::Style::FontWeight::Bold);
+Rml::LoadFontFace(trilobyte_b, "Trilobyte", Rml::Style::FontStyle::Normal, Rml::Style::FontWeight::Bold);
 
 /* ... */
 

--- a/pages/lua_manual/api_reference.md
+++ b/pages/lua_manual/api_reference.md
@@ -1145,7 +1145,7 @@ Inherits: `nil`{: .lua-type }
 | Name | Return Type |
 | ------------ | ---- |
 | [CreateContext](#LuaRmlUi-CreateContext){: .lua-function }(`string`{: .lua-type } name, `Vector2i`{: .lua-type } dimensions) | `nil`{: .lua-type }<br>`Context`{: .lua-type }<br> |
-| [LoadFontFace](#LuaRmlUi-LoadFontFace){: .lua-function }(`string`{: .lua-type } path) | `boolean`{: .lua-type }<br> |
+| [LoadFontFace](#LuaRmlUi-LoadFontFace){: .lua-function }(`string`{: .lua-type } path, `boolean`{: .lua-type } fallback, `integer`{: .lua-type } face_index) | `boolean`{: .lua-type }<br> |
 | [RegisterTag](#LuaRmlUi-RegisterTag){: .lua-function }(`string`{: .lua-type } tag) | `nil`{: .lua-type } |
 
 
@@ -1165,8 +1165,8 @@ Inherits: `nil`{: .lua-type }
 <a href='#LuaRmlUi-CreateContext' name='LuaRmlUi-CreateContext'>CreateContext</a>{: .lua-function }(`string`{: .lua-type } name, `Vector2i`{: .lua-type } dimensions)  &rarr; `Context`{: .lua-type }, `Context`{: .lua-type }
 : Create RmlUi context with specified `dimensions`.
 
-<a href='#LuaRmlUi-LoadFontFace' name='LuaRmlUi-LoadFontFace'>LoadFontFace</a>{: .lua-function }(`string`{: .lua-type } path)  &rarr; `boolean`{: .lua-type }
-: Load font face at `path`
+<a href='#LuaRmlUi-LoadFontFace' name='LuaRmlUi-LoadFontFace'>LoadFontFace</a>{: .lua-function }(`string`{: .lua-type } path, `boolean`{: .lua-type } fallback, `integer`{: .lua-type } face_index)  &rarr; `boolean`{: .lua-type }
+: Load font face at `path`. Use the `fallback` option to make the given font face used for any unknown characters in other fonts. The `face_index` optional parameter allows selection of font faces within font collections.
 
 <a href='#LuaRmlUi-RegisterTag' name='LuaRmlUi-RegisterTag'>RegisterTag</a>{: .lua-function }(`string`{: .lua-type } tag)  &rarr; `nil`{: .lua-type}
 : Register tag to element instancer.

--- a/pages/lua_manual/fonts.md
+++ b/pages/lua_manual/fonts.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Loading Fonts
+title: Loading fonts
 parent: lua_manual
 next: attaching_to_events
 ---
@@ -19,7 +19,7 @@ rmlui.LoadFontFace('../assets/LatoLatin-Bold.ttf')
 
 However, you may provide two additional parameters (in this order):
 
-- A `fallback` option as a `boolean` type. If enables, it makes the given font face be used for any unknown characters in other fonts. This is useful for example to provide a single font face for emojis, and another one providing characters for Cyrillic, Greek, and similar. These fonts will then be used whenever characters encountered are not located in the fonts specified by the document. Multiple fallback faces can be used, and they will be prioritized in the order they were loaded.
+- A `fallback` option as a `boolean` type. If enabled, it makes the given font face be used for any unknown characters in other fonts. This is useful for example to provide a single font face for emojis, and another one providing characters for Cyrillic, Greek, and similar. These fonts will then be used whenever characters encountered are not located in the fonts specified by the document. Multiple fallback faces can be used, and they will be prioritized in the order they were loaded.
 - A `face_index` parameter as an `integer` type. It allows selection of font faces within font collections. This is useful for loading a single font file with multiple faces.
 
 In this example, different weights of the same font face are loaded, as they are all part of the same file (see [OpenType Font Variations](https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview)), and a fallback for emojis is included:

--- a/pages/lua_manual/fonts.md
+++ b/pages/lua_manual/fonts.md
@@ -22,7 +22,7 @@ However, you may provide two additional parameters (in this order):
 - A `fallback` option as a `boolean` type. If enables, it makes the given font face be used for any unknown characters in other fonts. This is useful for example to provide a single font face for emojis, and another one providing characters for Cyrillic, Greek, and similar. These fonts will then be used whenever characters encountered are not located in the fonts specified by the document. Multiple fallback faces can be used, and they will be prioritized in the order they were loaded.
 - A `face_index` parameter as an `integer` type. It allows selection of font faces within font collections. This is useful for loading a single font file with multiple faces.
 
-In this example, different weights of the same font are loaded, and a fallback for emojis is included:
+In this example, different weights of the same font face are loaded, as they are all part of the same file (see [OpenType Font Variations](https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview)), and a fallback for emojis is included:
 
 ```python
 rmlui.LoadFontFace('data/NotoSansJP-VariableFont_wght.ttf', false, 0)

--- a/pages/lua_manual/fonts.md
+++ b/pages/lua_manual/fonts.md
@@ -1,15 +1,32 @@
 ---
 layout: page
-title: Loading fonts
+title: Loading Fonts
 parent: lua_manual
 next: attaching_to_events
 ---
 
-The Lua plugin installs a global table `rmlui`, which provides a way to load supported font files from Lua. The function takes a single string as a parameter, the file name of the font to load.
+- [rmlui Lua API reference](api_reference.html#rmlui)
+- [Loading Fonts C++ manual](../cpp_manual/fonts.html)
+
+---
+
+The Lua plugin installs a global table `rmlui`, which provides a way to load supported font files from Lua. The simplest way to load a font face is executing the `LoadFontFace()` function with a single string as a parameter, the file name of the font to load:
 
 ```python
 rmlui.LoadFontFace('../assets/LatoLatin-Regular.ttf')
 rmlui.LoadFontFace('../assets/LatoLatin-Bold.ttf')
 ```
 
-See the RmlUi [Lua API reference](api_reference.html#rmlui) for other things to do with this global.
+However, you may provide two additional parameters (in this order):
+
+- A `fallback` option as a `boolean` type. If enables, it makes the given font face be used for any unknown characters in other fonts. This is useful for example to provide a single font face for emojis, and another one providing characters for Cyrillic, Greek, and similar. These fonts will then be used whenever characters encountered are not located in the fonts specified by the document. Multiple fallback faces can be used, and they will be prioritized in the order they were loaded.
+- A `face_index` parameter as an `integer` type. It allows selection of font faces within font collections. This is useful for loading a single font file with multiple faces.
+
+In this example, different weights of the same font are loaded, and a fallback for emojis is included:
+
+```python
+rmlui.LoadFontFace('data/NotoSansJP-VariableFont_wght.ttf', false, 0)
+rmlui.LoadFontFace('data/NotoSansJP-VariableFont_wght.ttf', false, 1)
+rmlui.LoadFontFace('data/NotoSansJP-VariableFont_wght.ttf', false, 2)
+rmlui.LoadFontFace('seguiemj.ttf', true)
+```


### PR DESCRIPTION
This covers mikke89/RmlUi#720 and mikke89/RmlUi#764.

I first wanted to cover only the Lua change, but then I noticed that the Lua documentation for fonts is very empty, and the C++ counterpart is outdated. I see you mentioned this before (https://github.com/mikke89/RmlUi/pull/720#issuecomment-2628910381), so hopefully I have not missed anything. \:)